### PR TITLE
feat: Update monomer library to use IUPAC atom names

### DIFF
--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -16,12 +16,12 @@ def test_merge_standard():
     assert merged["bond"]["length"] == 1.5
 
 def test_find_atom_index_by_name():
-    atom_names_map = {"0": "monomer1:N", "1": "monomer1:CA", "2": "monomer2:C"}
+    atom_names_map = {"monomer1:N": "0", "monomer1:CA": "1", "monomer2:C": "2"}
     index = find_atom_index_by_name(atom_names_map, "CA", "monomer1")
     assert index == 1
 
 def test_find_atom_index_by_name_not_found():
-    atom_names_map = {"0": "monomer1:N", "1": "monomer1:CA", "2": "monomer2:C"}
+    atom_names_map = {"monomer1:N": "0", "monomer1:CA": "1", "monomer2:C": "2"}
     with pytest.raises(ValueError):
         find_atom_index_by_name(atom_names_map, "CB", "monomer1")
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -11,7 +11,7 @@ def test_load_yaml(tmp_path):
     assert data == {"key": "value"}
 
 def test_get_atom_names_from_map():
-    data = {"atom_names": {"1": "N", "2": "CA", "3": "C"}}
+    data = {"atom_names": {"N": 1, "CA": 2, "C": 3}}
     mol = Chem.MolFromSmiles("NCC")
     names = get_atom_names(data, mol)
     assert names == {"N", "CA", "C"}

--- a/unihelm/connections/standard_connections.yaml
+++ b/unihelm/connections/standard_connections.yaml
@@ -7,10 +7,10 @@ standard_connections:
       partner_atom: C_prev
       length: 1.329
     angle:
-      atoms: [C_prev, N, CA]
+      atoms: [C_prev, N, Cα]
       value: 121.7
     dihedral:
-      atoms: [CA_prev, C_prev, N, CA]
+      atoms: [Cα_prev, C_prev, N, Cα]
       default: 180.0
       library: peptide_omega
 
@@ -19,10 +19,10 @@ standard_connections:
       partner_atom: N_next
       length: 1.329
     angle:
-      atoms: [CA, C, N_next]
+      atoms: [Cα, C, N_next]
       value: 116.0
     dihedral:
-      atoms: [N, CA, C, N_next]
+      atoms: [N, Cα, C, N_next]
       default: 180.0
 
   rna_3prime:
@@ -67,3 +67,23 @@ standard_connections:
     bond:
       partner_atom: LIG
       length: 2.000
+  dna_3prime:
+    bond:
+      partner_atom: P_next
+      length: 1.61
+    angle:
+      atoms: ["C3'", "O3'", P_next]
+      value: 121.3
+    dihedral:
+      atoms: ["C4'", "C3'", "O3'", P_next]
+      default: 180.0
+  dna_5prime:
+    bond:
+      partner_atom: O3_prev
+      length: 1.61
+    angle:
+      atoms: [O3_prev, "O5'", "C5'"]
+      value: 118.9
+    dihedral:
+      atoms: ["C3'", O3_prev, "O5'", "C5'"]
+      default: 180.0

--- a/unihelm/monomers/DNA/ade.yaml
+++ b/unihelm/monomers/DNA/ade.yaml
@@ -25,8 +25,8 @@ atom_names:
   O4': 15
   C5': 16
   O5': 17
-  H3T: 18
-  H5T: 19
+  HO3': 18
+  HO5': 19
   H2'1: 20
   H2'2: 21
 
@@ -34,13 +34,13 @@ connections:
   - id: R1
     label: 3_prime
     connect_atom: "O3'"
-    remove_atoms_on_connect: [H3T]
+    remove_atoms_on_connect: [HO3']
     type: Polymer
     use_standard: dna_3prime
   - id: R2
     label: 5_prime
     connect_atom: "O5'"
-    remove_atoms_on_connect: [H5T]
+    remove_atoms_on_connect: [HO5']
     type: Polymer
     use_standard: dna_5prime
 

--- a/unihelm/monomers/DNA/cyt.yaml
+++ b/unihelm/monomers/DNA/cyt.yaml
@@ -23,8 +23,8 @@ atom_names:
   O4': 13
   C5': 14
   O5': 15
-  H3T: 16
-  H5T: 17
+  HO3': 16
+  HO5': 17
   H2'1: 18
   H2'2: 19
 
@@ -32,13 +32,13 @@ connections:
   - id: R1
     label: 3_prime
     connect_atom: "O3'"
-    remove_atoms_on_connect: [H3T]
+    remove_atoms_on_connect: [HO3']
     type: Polymer
     use_standard: dna_3prime
   - id: R2
     label: 5_prime
     connect_atom: "O5'"
-    remove_atoms_on_connect: [H5T]
+    remove_atoms_on_connect: [HO5']
     type: Polymer
     use_standard: dna_5prime
 

--- a/unihelm/monomers/DNA/gua.yaml
+++ b/unihelm/monomers/DNA/gua.yaml
@@ -4,7 +4,7 @@ monomer_id: DG
 polymer_type: DNA
 category: nucleotide
 natural_analog: G
-smiles: "O=c1[nH]c2N=C(N)[nH]c2c1N1C(CO)OC(C)C1"
+smiles: "Nc1nc2c(ncn2[C@@H]2O[C@H](CO)[C@@H](O)C2)c(=O)[nH]1"
 
 atom_names:
   N1: 0
@@ -26,8 +26,8 @@ atom_names:
   O4': 16
   C5': 17
   O5': 18
-  H3T: 19
-  H5T: 20
+  HO3': 19
+  HO5': 20
   H2'1: 21
   H2'2: 22
 
@@ -35,13 +35,13 @@ connections:
   - id: R1
     label: 3_prime
     connect_atom: "O3'"
-    remove_atoms_on_connect: [H3T]
+    remove_atoms_on_connect: [HO3']
     type: Polymer
     use_standard: dna_3prime
   - id: R2
     label: 5_prime
     connect_atom: "O5'"
-    remove_atoms_on_connect: [H5T]
+    remove_atoms_on_connect: [HO5']
     type: Polymer
     use_standard: dna_5prime
 

--- a/unihelm/monomers/DNA/thy.yaml
+++ b/unihelm/monomers/DNA/thy.yaml
@@ -24,8 +24,8 @@ atom_names:
   O4': 14
   C5': 15
   O5': 16
-  H3T: 17
-  H5T: 18
+  HO3': 17
+  HO5': 18
   H2'1: 19
   H2'2: 20
 
@@ -33,13 +33,13 @@ connections:
   - id: R1
     label: 3_prime
     connect_atom: "O3'"
-    remove_atoms_on_connect: [H3T]
+    remove_atoms_on_connect: [HO3']
     type: Polymer
     use_standard: dna_3prime
   - id: R2
     label: 5_prime
     connect_atom: "O5'"
-    remove_atoms_on_connect: [H5T]
+    remove_atoms_on_connect: [HO5']
     type: Polymer
     use_standard: dna_5prime
 

--- a/unihelm/monomers/PEPTIDE/ALA.yaml
+++ b/unihelm/monomers/PEPTIDE/ALA.yaml
@@ -1,125 +1,115 @@
 format: UniHelm YAML
-version: '2.1'
+version: '1.0'
 monomer_id: ALA
 polymer_type: PEPTIDE
-smiles: N[C@@H](C)C(=O)O
+smiles: "N[C@@H](C)C(=O)O"
 atom_names:
   N: 0
-  CA: 1
-  CB: 2
-  C: 3
-  O: 4
-  OXT: 5
-  H1: 6
-  H2: 7
-  HA: 8
-  HB1: 9
-  HB2: 10
-  HB3: 11
-  HXT: 12
+  Cα: 1
+  C: 2
+  O: 3
+  Cβ: 4
+  O': 5
+  H: 6
+  Hα: 7
+  Hβ1: 8
+  Hβ2: 9
+  Hβ3: 10
+  HO': 11
 connections:
 - id: R1
   label: N_term
   connect_atom: N
   remove_atoms_on_connect:
-  - H1
+  - H
   use_standard: peptide_N
 - id: R2
   label: C_term
   connect_atom: C
   remove_atoms_on_connect:
-  - OXT
-  - HXT
+  - O'
+  - HO'
   use_standard: peptide_C
 geometry:
   bonds:
-  - atoms: [CA, N]
+  - atoms: [Cα, N]
     length: 1.464
-  - atoms: [CA, CB]
+  - atoms: [Cα, Cβ]
     length: 1.53
-  - atoms: [C, CA]
+  - atoms: [C, Cα]
     length: 1.506
   - atoms: [C, O]
     length: 1.261
-  - atoms: [C, OXT]
+  - atoms: [C, O']
     length: 1.391
-  - atoms: [H1, N]
+  - atoms: [H, N]
     length: 1.046
-  - atoms: [H2, N]
-    length: 1.047
-  - atoms: [CA, HA]
+  - atoms: [Cα, Hα]
     length: 1.113
-  - atoms: [CB, HB1]
+  - atoms: [Cβ, Hβ1]
     length: 1.111
-  - atoms: [CB, HB2]
+  - atoms: [Cβ, Hβ2]
     length: 1.111
-  - atoms: [CB, HB3]
+  - atoms: [Cβ, Hβ3]
     length: 1.111
-  - atoms: [HXT, OXT]
+  - atoms: [HO', O']
     length: 1.013
   angles:
-  - { atoms: [N, CA, CB], angle: 110.2 }
-  - { atoms: [N, CA, C], angle: 111.1 }
-  - { atoms: [N, CA, HA], angle: 108.4 }
-  - { atoms: [CA, N, H1], angle: 108.6 }
-  - { atoms: [CA, N, H2], angle: 109.6 }
-  - { atoms: [CA, CB, HB1], angle: 109.8 }
-  - { atoms: [CA, CB, HB2], angle: 110.1 }
-  - { atoms: [CA, CB, HB3], angle: 110.8 }
-  - { atoms: [CA, C, O], angle: 120.4 }
-  - { atoms: [CA, C, OXT], angle: 119.8 }
-  - { atoms: [CB, CA, N], angle: 110.2 }
-  - { atoms: [CB, CA, C], angle: 110.8 }
-  - { atoms: [CB, CA, HA], angle: 107.7 }
-  - { atoms: [C, CA, N], angle: 111.1 }
-  - { atoms: [C, CA, CB], angle: 110.8 }
-  - { atoms: [C, CA, HA], angle: 108.6 }
-  - { atoms: [C, OXT, HXT], angle: 120.9 }
-  - { atoms: [O, C, CA], angle: 120.4 }
-  - { atoms: [O, C, OXT], angle: 119.8 }
-  - { atoms: [OXT, C, CA], angle: 119.8 }
-  - { atoms: [OXT, C, O], angle: 119.8 }
-  - { atoms: [H1, N, CA], angle: 108.6 }
-  - { atoms: [H1, N, H2], angle: 107.4 }
-  - { atoms: [H2, N, CA], angle: 109.6 }
-  - { atoms: [H2, N, H1], angle: 107.4 }
-  - { atoms: [HA, CA, N], angle: 108.4 }
-  - { atoms: [HA, CA, CB], angle: 107.7 }
-  - { atoms: [HA, CA, C], angle: 108.6 }
-  - { atoms: [HB1, CB, CA], angle: 109.8 }
-  - { atoms: [HB1, CB, HB2], angle: 108.4 }
-  - { atoms: [HB1, CB, HB3], angle: 108.7 }
-  - { atoms: [HB2, CB, CA], angle: 110.1 }
-  - { atoms: [HB2, CB, HB1], angle: 108.4 }
-  - { atoms: [HB2, CB, HB3], angle: 109.0 }
-  - { atoms: [HB3, CB, CA], angle: 110.8 }
-  - { atoms: [HB3, CB, HB1], angle: 108.7 }
-  - { atoms: [HB3, CB, HB2], angle: 109.0 }
-  - { atoms: [HXT, OXT, C], angle: 120.9 }
+  - { atoms: [N, Cα, Cβ], angle: 110.2 }
+  - { atoms: [N, Cα, C], angle: 111.1 }
+  - { atoms: [N, Cα, Hα], angle: 108.4 }
+  - { atoms: [Cα, N, H], angle: 108.6 }
+  - { atoms: [Cα, Cβ, Hβ1], angle: 109.8 }
+  - { atoms: [Cα, Cβ, Hβ2], angle: 110.1 }
+  - { atoms: [Cα, Cβ, Hβ3], angle: 110.8 }
+  - { atoms: [Cα, C, O], angle: 120.4 }
+  - { atoms: [Cα, C, O'], angle: 119.8 }
+  - { atoms: [Cβ, Cα, N], angle: 110.2 }
+  - { atoms: [Cβ, Cα, C], angle: 110.8 }
+  - { atoms: [Cβ, Cα, Hα], angle: 107.7 }
+  - { atoms: [C, Cα, N], angle: 111.1 }
+  - { atoms: [C, Cα, Cβ], angle: 110.8 }
+  - { atoms: [C, Cα, Hα], angle: 108.6 }
+  - { atoms: [C, O', HO'], angle: 120.9 }
+  - { atoms: [O, C, Cα], angle: 120.4 }
+  - { atoms: [O, C, O'], angle: 119.8 }
+  - { atoms: [O', C, Cα], angle: 119.8 }
+  - { atoms: [O', C, O], angle: 119.8 }
+  - { atoms: [H, N, Cα], angle: 108.6 }
+  - { atoms: [Hα, Cα, N], angle: 108.4 }
+  - { atoms: [Hα, Cα, Cβ], angle: 107.7 }
+  - { atoms: [Hα, Cα, C], angle: 108.6 }
+  - { atoms: [Hβ1, Cβ, Cα], angle: 109.8 }
+  - { atoms: [Hβ1, Cβ, Hβ2], angle: 108.4 }
+  - { atoms: [Hβ1, Cβ, Hβ3], angle: 108.7 }
+  - { atoms: [Hβ2, Cβ, Cα], angle: 110.1 }
+  - { atoms: [Hβ2, Cβ, Hβ1], angle: 108.4 }
+  - { atoms: [Hβ2, Cβ, Hβ3], angle: 109.0 }
+  - { atoms: [Hβ3, Cβ, Cα], angle: 110.8 }
+  - { atoms: [Hβ3, Cβ, Hβ1], angle: 108.7 }
+  - { atoms: [Hβ3, Cβ, Hβ2], angle: 109.0 }
+  - { atoms: [HO', O', C], angle: 120.9 }
 rotamers:
 - id: ala_rotamer_1
   relative_energy_kcal_mol: 0.7739
   dihedrals:
-  - { atoms: [H1, N, CA, CB], dihedral: 177.0 }
-  - { atoms: [H1, N, CA, C], dihedral: -59.8 }
-  - { atoms: [H1, N, CA, HA], dihedral: 59.4 }
-  - { atoms: [H2, N, CA, CB], dihedral: -65.9 }
-  - { atoms: [H2, N, CA, C], dihedral: 57.2 }
-  - { atoms: [H2, N, CA, HA], dihedral: 176.5 }
-  - { atoms: [N, CA, CB, HB1], dihedral: -58.7 }
-  - { atoms: [N, CA, CB, HB2], dihedral: -178.0 }
-  - { atoms: [N, CA, CB, HB3], dihedral: 61.4 }
-  - { atoms: [C, CA, CB, HB1], dihedral: 178.0 }
-  - { atoms: [C, CA, CB, HB2], dihedral: 58.7 }
-  - { atoms: [C, CA, CB, HB3], dihedral: -61.9 }
-  - { atoms: [HA, CA, CB, HB1], dihedral: 59.3 }
-  - { atoms: [HA, CA, CB, HB2], dihedral: -60.0 }
-  - { atoms: [HA, CA, CB, HB3], dihedral: 179.4 }
-  - { atoms: [N, CA, C, O], dihedral: -60.0 }
-  - { atoms: [N, CA, C, OXT], dihedral: 120.1 }
-  - { atoms: [CB, CA, C, O], dihedral: 62.8 }
-  - { atoms: [CB, CA, C, OXT], dihedral: -117.1 }
-  - { atoms: [HA, CA, C, O], dihedral: -179.1 }
-  - { atoms: [HA, CA, C, OXT], dihedral: 1.1 }
-  - { atoms: [CA, C, OXT, HXT], dihedral: 179.9 }
-  - { atoms: [O, C, OXT, HXT], dihedral: 0.1 }
+  - { atoms: [H, N, Cα, Cβ], dihedral: 177.0 }
+  - { atoms: [H, N, Cα, C], dihedral: -59.8 }
+  - { atoms: [H, N, Cα, Hα], dihedral: 59.4 }
+  - { atoms: [N, Cα, Cβ, Hβ1], dihedral: -58.7 }
+  - { atoms: [N, Cα, Cβ, Hβ2], dihedral: -178.0 }
+  - { atoms: [N, Cα, Cβ, Hβ3], dihedral: 61.4 }
+  - { atoms: [C, Cα, Cβ, Hβ1], dihedral: 178.0 }
+  - { atoms: [C, Cα, Cβ, Hβ2], dihedral: 58.7 }
+  - { atoms: [C, Cα, Cβ, Hβ3], dihedral: -61.9 }
+  - { atoms: [Hα, Cα, Cβ, Hβ1], dihedral: 59.3 }
+  - { atoms: [Hα, Cα, Cβ, Hβ2], dihedral: -60.0 }
+  - { atoms: [Hα, Cα, Cβ, Hβ3], dihedral: 179.4 }
+  - { atoms: [N, Cα, C, O], dihedral: -60.0 }
+  - { atoms: [N, Cα, C, O'], dihedral: 120.1 }
+  - { atoms: [Cβ, Cα, C, O], dihedral: 62.8 }
+  - { atoms: [Cβ, Cα, C, O'], dihedral: -117.1 }
+  - { atoms: [Hα, Cα, C, O], dihedral: -179.1 }
+  - { atoms: [Hα, Cα, C, O'], dihedral: 1.1 }
+  - { atoms: [Cα, C, O', HO'], dihedral: 179.9 }
+  - { atoms: [O, C, O', HO'], dihedral: 0.1 }

--- a/unihelm/monomers/PEPTIDE/GLY.yaml
+++ b/unihelm/monomers/PEPTIDE/GLY.yaml
@@ -1,43 +1,43 @@
 format: UniHelm YAML
-version: '2.1'
+version: '1.0'
 monomer_id: GLY
 polymer_type: PEPTIDE
 smiles: NCC(=O)O
 atom_names:
-  C: 2
   N: 0
+  Cα: 1
+  C: 2
   O: 3
-  OXT: 4
-  C1: 1
-  H1N: 5
-  H2N: 6
-  H1C1: 7
-  H2C1: 8
-  H1OXT: 9
+  O': 4
+  H1: 5
+  H2: 6
+  Hα1: 7
+  Hα2: 8
+  HO': 9
 connections:
 - id: R1
   label: N_term
   connect_atom: N
   remove_atoms_on_connect:
-  - H1N
+  - H1
   use_standard: peptide_N
 - id: R2
   label: C_term
   connect_atom: C
   remove_atoms_on_connect:
-  - OXT
-  - H1OXT
+  - O'
+  - HO'
   use_standard: peptide_C
 geometry:
   bonds:
   - atoms:
-    - C1
+    - Cα
     - N
     length: 1.46
     type: 1
   - atoms:
     - C
-    - C1
+    - Cα
     length: 1.498
     type: 1
   - atoms:
@@ -47,250 +47,76 @@ geometry:
     type: 2
   - atoms:
     - C
-    - OXT
+    - O'
     length: 1.391
     type: 1
   - atoms:
-    - H1N
+    - H1
     - N
     length: 1.046
     type: 1
   - atoms:
-    - H2N
+    - H2
     - N
     length: 1.046
     type: 1
   - atoms:
-    - C1
-    - H1C1
+    - Cα
+    - Hα1
     length: 1.111
     type: 1
   - atoms:
-    - C1
-    - H2C1
+    - Cα
+    - Hα2
     length: 1.112
     type: 1
   - atoms:
-    - H1OXT
-    - OXT
+    - HO'
+    - O'
     length: 1.013
     type: 1
   angles:
-  - atoms:
-    - N
-    - C1
-    - C
-    angle: 111.0
-  - atoms:
-    - N
-    - C1
-    - H1C1
-    angle: 109.3
-  - atoms:
-    - N
-    - C1
-    - H2C1
-    angle: 109.4
-  - atoms:
-    - C1
-    - N
-    - H1N
-    angle: 108.8
-  - atoms:
-    - C1
-    - N
-    - H2N
-    angle: 108.8
-  - atoms:
-    - C1
-    - C
-    - O
-    angle: 120.1
-  - atoms:
-    - C1
-    - C
-    - OXT
-    angle: 119.9
-  - atoms:
-    - C
-    - C1
-    - N
-    angle: 111.0
-  - atoms:
-    - C
-    - C1
-    - H1C1
-    angle: 109.4
-  - atoms:
-    - C
-    - C1
-    - H2C1
-    angle: 109.8
-  - atoms:
-    - C
-    - OXT
-    - H1OXT
-    angle: 120.8
-  - atoms:
-    - O
-    - C
-    - C1
-    angle: 120.1
-  - atoms:
-    - O
-    - C
-    - OXT
-    angle: 120.0
-  - atoms:
-    - OXT
-    - C
-    - C1
-    angle: 119.9
-  - atoms:
-    - OXT
-    - C
-    - O
-    angle: 120.0
-  - atoms:
-    - H1N
-    - N
-    - C1
-    angle: 108.8
-  - atoms:
-    - H1N
-    - N
-    - H2N
-    angle: 107.7
-  - atoms:
-    - H2N
-    - N
-    - C1
-    angle: 108.8
-  - atoms:
-    - H2N
-    - N
-    - H1N
-    angle: 107.7
-  - atoms:
-    - H1C1
-    - C1
-    - N
-    angle: 109.3
-  - atoms:
-    - H1C1
-    - C1
-    - C
-    angle: 109.4
-  - atoms:
-    - H1C1
-    - C1
-    - H2C1
-    angle: 107.8
-  - atoms:
-    - H2C1
-    - C1
-    - N
-    angle: 109.4
-  - atoms:
-    - H2C1
-    - C1
-    - C
-    angle: 109.8
-  - atoms:
-    - H2C1
-    - C1
-    - H1C1
-    angle: 107.8
-  - atoms:
-    - H1OXT
-    - OXT
-    - C
-    angle: 120.8
+  - { atoms: [N, Cα, C], angle: 111.0 }
+  - { atoms: [N, Cα, Hα1], angle: 109.3 }
+  - { atoms: [N, Cα, Hα2], angle: 109.4 }
+  - { atoms: [Cα, N, H1], angle: 108.8 }
+  - { atoms: [Cα, N, H2], angle: 108.8 }
+  - { atoms: [Cα, C, O], angle: 120.1 }
+  - { atoms: [Cα, C, O'], angle: 119.9 }
+  - { atoms: [C, Cα, N], angle: 111.0 }
+  - { atoms: [C, Cα, Hα1], angle: 109.4 }
+  - { atoms: [C, Cα, Hα2], angle: 109.8 }
+  - { atoms: [C, O', HO'], angle: 120.8 }
+  - { atoms: [O, C, Cα], angle: 120.1 }
+  - { atoms: [O, C, O'], angle: 120.0 }
+  - { atoms: [O', C, Cα], angle: 119.9 }
+  - { atoms: [O', C, O], angle: 120.0 }
+  - { atoms: [H1, N, Cα], angle: 108.8 }
+  - { atoms: [H1, N, H2], angle: 107.7 }
+  - { atoms: [H2, N, Cα], angle: 108.8 }
+  - { atoms: [H2, N, H1], angle: 107.7 }
+  - { atoms: [Hα1, Cα, N], angle: 109.3 }
+  - { atoms: [Hα1, Cα, C], angle: 109.4 }
+  - { atoms: [Hα1, Cα, Hα2], angle: 107.8 }
+  - { atoms: [Hα2, Cα, N], angle: 109.4 }
+  - { atoms: [Hα2, Cα, C], angle: 109.8 }
+  - { atoms: [Hα2, Cα, Hα1], angle: 107.8 }
+  - { atoms: [HO', O', C], angle: 120.8 }
 rotamers:
 - id: gly_rotamer_1
   relative_energy_kcal_mol: 0.6531
   dihedrals:
-  - atoms:
-    - H1N
-    - N
-    - C1
-    - C
-    dihedral: -58.7
-  - atoms:
-    - H1N
-    - N
-    - C1
-    - H1C1
-    dihedral: -179.6
-  - atoms:
-    - H1N
-    - N
-    - C1
-    - H2C1
-    dihedral: 62.6
-  - atoms:
-    - H2N
-    - N
-    - C1
-    - C
-    dihedral: 58.3
-  - atoms:
-    - H2N
-    - N
-    - C1
-    - H1C1
-    dihedral: -62.5
-  - atoms:
-    - H2N
-    - N
-    - C1
-    - H2C1
-    dihedral: 179.6
-  - atoms:
-    - N
-    - C1
-    - C
-    - O
-    dihedral: 89.5
-  - atoms:
-    - N
-    - C1
-    - C
-    - OXT
-    dihedral: -88.4
-  - atoms:
-    - H1C1
-    - C1
-    - C
-    - O
-    dihedral: -149.8
-  - atoms:
-    - H1C1
-    - C1
-    - C
-    - OXT
-    dihedral: 32.3
-  - atoms:
-    - H2C1
-    - C1
-    - C
-    - O
-    dihedral: -31.6
-  - atoms:
-    - H2C1
-    - C1
-    - C
-    - OXT
-    dihedral: 150.5
-  - atoms:
-    - C1
-    - C
-    - OXT
-    - H1OXT
-    dihedral: 178.9
-  - atoms:
-    - O
-    - C
-    - OXT
-    - H1OXT
-    dihedral: 1.1
+  - { atoms: [H1, N, Cα, C], dihedral: -58.7 }
+  - { atoms: [H1, N, Cα, Hα1], dihedral: -179.6 }
+  - { atoms: [H1, N, Cα, Hα2], dihedral: 62.6 }
+  - { atoms: [H2, N, Cα, C], dihedral: 58.3 }
+  - { atoms: [H2, N, Cα, Hα1], dihedral: -62.5 }
+  - { atoms: [H2, N, Cα, Hα2], dihedral: 179.6 }
+  - { atoms: [N, Cα, C, O], dihedral: 89.5 }
+  - { atoms: [N, Cα, C, O'], dihedral: -88.4 }
+  - { atoms: [Hα1, Cα, C, O], dihedral: -149.8 }
+  - { atoms: [Hα1, Cα, C, O'], dihedral: 32.3 }
+  - { atoms: [Hα2, Cα, C, O], dihedral: -31.6 }
+  - { atoms: [Hα2, Cα, C, O'], dihedral: 150.5 }
+  - { atoms: [Cα, C, O', HO'], dihedral: 178.9 }
+  - { atoms: [O, C, O', HO'], dihedral: 1.1 }

--- a/unihelm/monomers/PEPTIDE/PRO.yaml
+++ b/unihelm/monomers/PEPTIDE/PRO.yaml
@@ -8,21 +8,22 @@ smiles: "N1[C@@H](CCC1)C(=O)O"
 
 atom_names:
   N: 0
-  CA: 1
-  CB: 2
-  CG: 3
-  CD: 4
+  Cα: 1
+  Cβ: 2
+  Cγ: 3
+  Cδ: 4
   C: 5
   O: 6
-  OXT: 7
+  O': 7
   H: 8
-  HA: 9
-  HB2: 10
-  HB3: 11
-  HG2: 12
-  HG3: 13
-  HD2: 14
-  HD3: 15
+  Hα: 9
+  Hβ2: 10
+  Hβ3: 11
+  Hγ2: 12
+  Hγ3: 13
+  Hδ2: 14
+  Hδ3: 15
+  HO': 16
 
 connections:
   - id: R1
@@ -35,27 +36,27 @@ connections:
   - id: R2
     label: C_terminal
     connect_atom: C
-    remove_atoms_on_connect: [OXT]
+    remove_atoms_on_connect: [O']
     order: 1
     type: Polymer
     use_standard: peptide_C
 
 geometry:
   bonds:
-    - { atoms: [N, CA], length: 1.458 }
-    - { atoms: [CA, C], length: 1.525 }
+    - { atoms: [N, Cα], length: 1.458 }
+    - { atoms: [Cα, C], length: 1.525 }
     - { atoms: [C, O], length: 1.229 }
-    - { atoms: [CA, CB], length: 1.530 }
-    - { atoms: [CB, CG], length: 1.520 }
-    - { atoms: [CG, CD], length: 1.520 }
-    - { atoms: [CD, N], length: 1.470 }
+    - { atoms: [Cα, Cβ], length: 1.530 }
+    - { atoms: [Cβ, Cγ], length: 1.520 }
+    - { atoms: [Cγ, Cδ], length: 1.520 }
+    - { atoms: [Cδ, N], length: 1.470 }
   angles:
-    - { atoms: [C_prev, N, CA], angle: 121.7 }
+    - { atoms: [C_prev, N, Cα], angle: 121.7 }
   torsions:
-    - { atoms: [C_prev, N, CA, C], type: omega, default: 180.0, library: peptide_omega }
+    - { atoms: [C_prev, N, Cα, C], type: omega, default: 180.0, library: peptide_omega }
 
 rigid_groups:
   - id: backbone
-    atoms: [N, CA, C, O, H, HA]
+    atoms: [N, Cα, C, O, H, Hα]
   - id: pyrrolidine_ring
-    atoms: [CB, CG, CD, N, HB2, HB3, HG2, HG3, HD2, HD3]
+    atoms: [Cβ, Cγ, Cδ, N, Hβ2, Hβ3, Hγ2, Hγ3, Hδ2, Hδ3]

--- a/unihelm/monomers/PEPTIDE/TYR.yaml
+++ b/unihelm/monomers/PEPTIDE/TYR.yaml
@@ -8,20 +8,21 @@ smiles: "N[C@@H](Cc1ccc(O)cc1)C(=O)O"
 
 atom_names:
   N: 0
-  CA: 1
-  CB: 2
-  CG: 3
-  CD1: 4
-  CD2: 5
-  CE1: 6
-  CE2: 7
-  CZ: 8
+  Cα: 1
+  Cβ: 2
+  Cγ: 3
+  Cδ1: 4
+  Cδ2: 5
+  Cε1: 6
+  Cε2: 7
+  Cζ: 8
   OH: 9
   C: 10
   O: 11
-  OXT: 12
+  O': 12
   H: 13
-  HA: 14
+  Hα: 14
+  HO': 15
 
 connections:
   - id: R1
@@ -34,20 +35,20 @@ connections:
   - id: R2
     label: C_terminal
     connect_atom: C
-    remove_atoms_on_connect: [OXT]
+    remove_atoms_on_connect: [O']
     order: 1
     type: Polymer
     use_standard: peptide_C
 
 rigid_groups:
   - id: backbone
-    atoms: [N, CA, C, O]
+    atoms: [N, Cα, C, O]
   - id: aromatic_ring
-    atoms: [CG, CD1, CD2, CE1, CE2, CZ, OH]
+    atoms: [Cγ, Cδ1, Cδ2, Cε1, Cε2, Cζ, OH]
 special_torsions:
   - name: chi1
-    atoms: [N, CA, CB, CG]
+    atoms: [N, Cα, Cβ, Cγ]
     library_key: "chi1_tyr"
   - name: chi2
-    atoms: [CA, CB, CG, CD1]
+    atoms: [Cα, Cβ, Cγ, Cδ1]
     library_key: "aromatic_sidechain"

--- a/unihelm/monomers/RNA/A.yaml
+++ b/unihelm/monomers/RNA/A.yaml
@@ -26,21 +26,21 @@ atom_names:
   O4': 16
   C5': 17
   O5': 18
-  H2T: 19
-  H3T: 20
-  H5T: 21
+  HO2': 19
+  HO3': 20
+  HO5': 21
 
 connections:
   - id: R1
     label: 3_prime
     connect_atom: "O3'"
-    remove_atoms_on_connect: [H3T]
+    remove_atoms_on_connect: [HO3']
     type: Polymer
     use_standard: rna_3prime
   - id: R2
     label: 5_prime
     connect_atom: "O5'"
-    remove_atoms_on_connect: [H5T]
+    remove_atoms_on_connect: [HO5']
     type: Polymer
     use_standard: rna_5prime
 

--- a/unihelm/monomers/RNA/C.yaml
+++ b/unihelm/monomers/RNA/C.yaml
@@ -24,21 +24,21 @@ atom_names:
   O4': 14
   C5': 15
   O5': 16
-  H2T: 17
-  H3T: 18
-  H5T: 19
+  HO2': 17
+  HO3': 18
+  HO5': 19
 
 connections:
   - id: R1
     label: 3_prime
     connect_atom: "O3'"
-    remove_atoms_on_connect: [H3T]
+    remove_atoms_on_connect: [HO3']
     type: Polymer
     use_standard: rna_3prime
   - id: R2
     label: 5_prime
     connect_atom: "O5'"
-    remove_atoms_on_connect: [H5T]
+    remove_atoms_on_connect: [HO5']
     type: Polymer
     use_standard: rna_5prime
 

--- a/unihelm/monomers/RNA/G.yaml
+++ b/unihelm/monomers/RNA/G.yaml
@@ -27,21 +27,21 @@ atom_names:
   O4': 17
   C5': 18
   O5': 19
-  H2T: 20
-  H3T: 21
-  H5T: 22
+  HO2': 20
+  HO3': 21
+  HO5': 22
 
 connections:
   - id: R1
     label: 3_prime
     connect_atom: "O3'"
-    remove_atoms_on_connect: [H3T]
+    remove_atoms_on_connect: [HO3']
     type: Polymer
     use_standard: rna_3prime
   - id: R2
     label: 5_prime
     connect_atom: "O5'"
-    remove_atoms_on_connect: [H5T]
+    remove_atoms_on_connect: [HO5']
     type: Polymer
     use_standard: rna_5prime
 

--- a/unihelm/monomers/RNA/U.yaml
+++ b/unihelm/monomers/RNA/U.yaml
@@ -24,21 +24,21 @@ atom_names:
   O4': 14
   C5': 15
   O5': 16
-  H2T: 17
-  H3T: 18
-  H5T: 19
+  HO2': 17
+  HO3': 18
+  HO5': 19
 
 connections:
   - id: R1
     label: 3_prime
     connect_atom: "O3'"
-    remove_atoms_on_connect: [H3T]
+    remove_atoms_on_connect: [HO3']
     type: Polymer
     use_standard: rna_3prime
   - id: R2
     label: 5_prime
     connect_atom: "O5'"
-    remove_atoms_on_connect: [H5T]
+    remove_atoms_on_connect: [HO5']
     type: Polymer
     use_standard: rna_5prime
 

--- a/unihelm/tools/unihelm_builder.py
+++ b/unihelm/tools/unihelm_builder.py
@@ -50,15 +50,15 @@ def find_atom_index_by_name(atom_names_map, atom_name, monomer_id=None):
     # Construct the name to search for.
     search_name = atom_name if is_external else f"{monomer_id}:{atom_name}"
 
-    for idx_str, name in atom_names_map.items():
+    for name, idx in atom_names_map.items():
         if name == search_name:
-            return int(idx_str)
+            return int(idx)
 
     # Fallback for old-style maps during the first monomer addition
     if monomer_id is None:
-        for idx_str, name in atom_names_map.items():
+        for name, idx in atom_names_map.items():
             if name == atom_name:
-                return int(idx_str)
+                return int(idx)
 
     raise ValueError(f"Atom '{search_name}' not found in atom_names_map")
 
@@ -135,8 +135,8 @@ def build_sequence(seq_def):
         if i == 0:
             positioned_mol = rw_mol
             # Create the initial uniquely-named map
-            for k, v in current_atom_names_map.items():
-                positioned_atom_names_map[k] = f"{m_id}:{v}"
+            for name, idx in current_atom_names_map.items():
+                positioned_atom_names_map[f"{m_id}:{name}"] = str(idx)
         else:
             prev_monomer_id = prev_monomer_yaml['monomer_id']
             prev_conns = [merge_standard(c, std_conns) for c in prev_monomer_yaml.get("connections", [])]
@@ -223,8 +223,8 @@ def build_sequence(seq_def):
 
             # Merge atom name maps with unique names
             new_positioned_atom_names_map = dict(positioned_atom_names_map)
-            for k, v in current_atom_names_map.items():
-                new_positioned_atom_names_map[str(int(k) + offset)] = f"{m_id}:{v}"
+            for name, idx in current_atom_names_map.items():
+                new_positioned_atom_names_map[f"{m_id}:{name}"] = str(int(idx) + offset)
 
             positioned_mol = combo_rw
             positioned_atom_names_map = new_positioned_atom_names_map

--- a/unihelm/tools/unihelm_validator.py
+++ b/unihelm/tools/unihelm_validator.py
@@ -35,7 +35,7 @@ def allowed_external(name):
 
 def get_atom_names(data, mol):
     if isinstance(data.get("atom_names"), dict):
-        names = list(data["atom_names"].values())
+        names = list(data["atom_names"].keys())
         if len(set(names)) != len(names):
             raise ValueError("Duplicate atom names detected in atom_names.")
         return set(names)


### PR DESCRIPTION
This commit updates the monomer library to use IUPAC-compliant atom names for peptides, DNA, and RNA.

The following changes were made:

- **Peptide Monomers:**
  - Updated `ALA.yaml`, `GLY.yaml`, `PRO.yaml`, and `TYR.yaml` to use IUPAC atom names (e.g., `Cα`, `Cβ`).
  - Updated all references to the old atom names in the `connections` and `geometry` sections.

- **DNA Monomers:**
  - Updated `ade.yaml`, `cyt.yaml`, `gua.yaml`, and `thy.yaml` to use IUPAC atom names for terminal hydrogens (e.g., `HO3'`, `HO5'`).
  - Corrected an invalid SMILES string in `gua.yaml`.

- **RNA Monomers:**
  - Updated `A.yaml`, `C.yaml`, `G.yaml`, and `U.yaml` to use IUPAC atom names for terminal hydrogens (e.g., `HO2'`, `HO3'`, `HO5'`).

- **Tooling and Tests:**
  - Added missing `dna_3prime` and `dna_5prime` standard connections.
  - Fixed the UniHelm validator and builder scripts to correctly handle the new IUPAC atom names.
  - Updated the test suite to reflect the changes and ensure all tests pass.