### PR TITLE
feat: Infer connection rigidity in builder

### DIFF
--- a/unihelm/monomers/PEPTIDE/ALA.yaml
+++ b/unihelm/monomers/PEPTIDE/ALA.yaml
@@ -2,13 +2,13 @@ format: UniHelm YAML
 version: '1.0'
 monomer_id: ALA
 polymer_type: PEPTIDE
-smiles: "CC(C(=O)O)N"
+smiles: "N[C@H](C)C(=O)O"
 atom_names:
   N: 0
   CA: 1
-  C: 2
-  O: 3
-  CB: 4
+  CB: 2
+  C: 3
+  O: 4
   OXT: 5
   HN: 6
   HA: 7
@@ -32,73 +32,73 @@ connections:
   use_standard: peptide_C
 geometry:
   bonds:
-  - { atoms: [CA, N], length: 1.464, type: 1 }
-  - { atoms: [CA, CB], length: 1.53, type: 1 }
-  - { atoms: [C, CA], length: 1.506, type: 1 }
-  - { atoms: [C, O], length: 1.261, type: 2 }
-  - { atoms: [C, OXT], length: 1.391, type: 1 }
-  - { atoms: [HN, N], length: 1.046, type: 1 }
-  - { atoms: [CA, HA], length: 1.113, type: 1 }
-  - { atoms: [CB, HB1], length: 1.111, type: 1 }
-  - { atoms: [CB, HB2], length: 1.111, type: 1 }
-  - { atoms: [CB, HB3], length: 1.111, type: 1 }
-  - { atoms: [HXT, OXT], length: 1.013, type: 1 }
+  - {atoms: [CA, N], length: 1.464, type: 1}
+  - {atoms: [CA, CB], length: 1.53, type: 1}
+  - {atoms: [C, CA], length: 1.506, type: 1}
+  - {atoms: [C, O], length: 1.261, type: 2}
+  - {atoms: [C, OXT], length: 1.391, type: 1}
+  - {atoms: [HN, N], length: 1.046, type: 1}
+  - {atoms: [CA, HA], length: 1.113, type: 1}
+  - {atoms: [CB, HB1], length: 1.111, type: 1}
+  - {atoms: [CB, HB2], length: 1.111, type: 1}
+  - {atoms: [CB, HB3], length: 1.111, type: 1}
+  - {atoms: [HXT, OXT], length: 1.013, type: 1}
   angles:
-  - { atoms: [N, CA, CB], angle: 110.2 }
-  - { atoms: [N, CA, C], angle: 111.1 }
-  - { atoms: [N, CA, HA], angle: 108.4 }
-  - { atoms: [CA, N, HN], angle: 108.6 }
-  - { atoms: [CA, CB, HB1], angle: 109.8 }
-  - { atoms: [CA, CB, HB2], angle: 110.1 }
-  - { atoms: [CA, CB, HB3], angle: 110.8 }
-  - { atoms: [CA, C, O], angle: 120.4 }
-  - { atoms: [CA, C, OXT], angle: 119.8 }
-  - { atoms: [CB, CA, N], angle: 110.2 }
-  - { atoms: [CB, CA, C], angle: 110.8 }
-  - { atoms: [CB, CA, HA], angle: 107.7 }
-  - { atoms: [C, CA, N], angle: 111.1 }
-  - { atoms: [C, CA, CB], angle: 110.8 }
-  - { atoms: [C, CA, HA], angle: 108.6 }
-  - { atoms: [C, OXT, HXT], angle: 120.9 }
-  - { atoms: [O, C, CA], angle: 120.4 }
-  - { atoms: [O, C, OXT], angle: 119.8 }
-  - { atoms: [OXT, C, CA], angle: 119.8 }
-  - { atoms: [OXT, C, O], angle: 119.8 }
-  - { atoms: [HN, N, CA], angle: 108.6 }
-  - { atoms: [HA, CA, N], angle: 108.4 }
-  - { atoms: [HA, CA, CB], angle: 107.7 }
-  - { atoms: [HA, CA, C], angle: 108.6 }
-  - { atoms: [HB1, CB, CA], angle: 109.8 }
-  - { atoms: [HB1, CB, HB2], angle: 108.4 }
-  - { atoms: [HB1, CB, HB3], angle: 108.7 }
-  - { atoms: [HB2, CB, CA], angle: 110.1 }
-  - { atoms: [HB2, CB, HB1], angle: 108.4 }
-  - { atoms: [HB2, CB, HB3], angle: 109.0 }
-  - { atoms: [HB3, CB, CA], angle: 110.8 }
-  - { atoms: [HB3, CB, HB1], angle: 108.7 }
-  - { atoms: [HB3, CB, HB2], angle: 109.0 }
-  - { atoms: [HXT, OXT, C], angle: 120.9 }
+  - {atoms: [N, CA, CB], angle: 110.2}
+  - {atoms: [N, CA, C], angle: 111.1}
+  - {atoms: [N, CA, HA], angle: 108.4}
+  - {atoms: [CA, N, HN], angle: 108.6}
+  - {atoms: [CA, CB, HB1], angle: 109.8}
+  - {atoms: [CA, CB, HB2], angle: 110.1}
+  - {atoms: [CA, CB, HB3], angle: 110.8}
+  - {atoms: [CA, C, O], angle: 120.4}
+  - {atoms: [CA, C, OXT], angle: 119.8}
+  - {atoms: [CB, CA, N], angle: 110.2}
+  - {atoms: [CB, CA, C], angle: 110.8}
+  - {atoms: [CB, CA, HA], angle: 107.7}
+  - {atoms: [C, CA, N], angle: 111.1}
+  - {atoms: [C, CA, CB], angle: 110.8}
+  - {atoms: [C, CA, HA], angle: 108.6}
+  - {atoms: [C, OXT, HXT], angle: 120.9}
+  - {atoms: [O, C, CA], angle: 120.4}
+  - {atoms: [O, C, OXT], angle: 119.8}
+  - {atoms: [OXT, C, CA], angle: 119.8}
+  - {atoms: [OXT, C, O], angle: 119.8}
+  - {atoms: [HN, N, CA], angle: 108.6}
+  - {atoms: [HA, CA, N], angle: 108.4}
+  - {atoms: [HA, CA, CB], angle: 107.7}
+  - {atoms: [HA, CA, C], angle: 108.6}
+  - {atoms: [HB1, CB, CA], angle: 109.8}
+  - {atoms: [HB1, CB, HB2], angle: 108.4}
+  - {atoms: [HB1, CB, HB3], angle: 108.7}
+  - {atoms: [HB2, CB, CA], angle: 110.1}
+  - {atoms: [HB2, CB, HB1], angle: 108.4}
+  - {atoms: [HB2, CB, HB3], angle: 109.0}
+  - {atoms: [HB3, CB, CA], angle: 110.8}
+  - {atoms: [HB3, CB, HB1], angle: 108.7}
+  - {atoms: [HB3, CB, HB2], angle: 109.0}
+  - {atoms: [HXT, OXT, C], angle: 120.9}
 rotamers:
 - id: ala_rotamer_1
   relative_energy_kcal_mol: 0.7739
   dihedrals:
-  - { atoms: [HN, N, CA, CB], dihedral: 177.0 }
-  - { atoms: [HN, N, CA, C], dihedral: -59.8 }
-  - { atoms: [HN, N, CA, HA], dihedral: 59.4 }
-  - { atoms: [N, CA, CB, HB1], dihedral: -58.7 }
-  - { atoms: [N, CA, CB, HB2], dihedral: -178.0 }
-  - { atoms: [N, CA, CB, HB3], dihedral: 61.4 }
-  - { atoms: [C, CA, CB, HB1], dihedral: 178.0 }
-  - { atoms: [C, CA, CB, HB2], dihedral: 58.7 }
-  - { atoms: [C, CA, CB, HB3], dihedral: -61.9 }
-  - { atoms: [HA, CA, CB, HB1], dihedral: 59.3 }
-  - { atoms: [HA, CA, CB, HB2], dihedral: -60.0 }
-  - { atoms: [HA, CA, CB, HB3], dihedral: 179.4 }
-  - { atoms: [N, CA, C, O], dihedral: -60.0 }
-  - { atoms: [N, CA, C, OXT], dihedral: 120.1 }
-  - { atoms: [CB, CA, C, O], dihedral: 62.8 }
-  - { atoms: [CB, CA, C, OXT], dihedral: -117.1 }
-  - { atoms: [HA, CA, C, O], dihedral: -179.1 }
-  - { atoms: [HA, CA, C, OXT], dihedral: 1.1 }
-  - { atoms: [CA, C, OXT, HXT], dihedral: 179.9 }
-  - { atoms: [O, C, OXT, HXT], dihedral: 0.1 }
+  - {atoms: [HN, N, CA, CB], dihedral: 177.0}
+  - {atoms: [HN, N, CA, C], dihedral: -59.8}
+  - {atoms: [HN, N, CA, HA], dihedral: 59.4}
+  - {atoms: [N, CA, CB, HB1], dihedral: -58.7}
+  - {atoms: [N, CA, CB, HB2], dihedral: -178.0}
+  - {atoms: [N, CA, CB, HB3], dihedral: 61.4}
+  - {atoms: [C, CA, CB, HB1], dihedral: 178.0}
+  - {atoms: [C, CA, CB, HB2], dihedral: 58.7}
+  - {atoms: [C, CA, CB, HB3], dihedral: -61.9}
+  - {atoms: [HA, CA, CB, HB1], dihedral: 59.3}
+  - {atoms: [HA, CA, CB, HB2], dihedral: -60.0}
+  - {atoms: [HA, CA, CB, HB3], dihedral: 179.4}
+  - {atoms: [N, CA, C, O], dihedral: -60.0}
+  - {atoms: [N, CA, C, OXT], dihedral: 120.1}
+  - {atoms: [CB, CA, C, O], dihedral: 62.8}
+  - {atoms: [CB, CA, C, OXT], dihedral: -117.1}
+  - {atoms: [HA, CA, C, O], dihedral: -179.1}
+  - {atoms: [HA, CA, C, OXT], dihedral: 1.1}
+  - {atoms: [CA, C, OXT, HXT], dihedral: 179.9}
+  - {atoms: [O, C, OXT, HXT], dihedral: 0.1}

--- a/unihelm/tools/unihelm_builder.py
+++ b/unihelm/tools/unihelm_builder.py
@@ -221,6 +221,13 @@ def build_sequence(seq_def):
             combo_rw = Chem.RWMol(combo)
             combo_rw.AddBond(prev_idx, offset + curr_idx, Chem.rdchem.BondType.SINGLE)
 
+            # After adding the bond, check if it should be marked as rigid
+            if "dihedral" in prev_cterm:
+                new_bond = combo_rw.GetBondBetweenAtoms(prev_idx, offset + curr_idx)
+                if new_bond:
+                    new_bond.SetBoolProp("is_rigid", True)
+                    log(f"   [Rigidity] Marked bond between atoms {prev_idx} and {offset + curr_idx} as rigid.")
+
             # Merge atom name maps with unique names
             new_positioned_atom_names_map = dict(positioned_atom_names_map)
             for name, idx in current_atom_names_map.items():


### PR DESCRIPTION
This commit modifies the polymer builder script (`unihelm_builder.py`) to infer bond rigidity from the connection template.

The key changes are:
- When building a polymer, if the connection template used to join two monomers contains a `dihedral` definition, the newly formed bond is marked with an `is_rigid=True` property. This allows downstream tools to correctly handle the rigidity of bonds like the peptide bond.
- The `ALA.yaml` monomer definition was updated to have a SMILES string that is consistent with the `atom_names` map. This fixes a data inconsistency that was causing a valence error in the builder.

This approach was chosen after a discussion with the user, where it was decided that defining connection rigidity in the builder is a more robust and chemically accurate solution than defining it in the individual monomer files.